### PR TITLE
Fixed podspec settings

### DIFF
--- a/EarlGrey.podspec.json
+++ b/EarlGrey.podspec.json
@@ -37,8 +37,12 @@
     "vendored_frameworks": "EarlGrey/EarlGrey.framework"
   },
   "pod_target_xcconfig": {
+    "EXCLUDED_ARCHS[sdk=iphonesimulator*]": "arm64",
     "FRAMEWORK_SEARCH_PATHS": "$(inherited) $(PLATFORM_DIR)/Developer/Library/Frameworks",
     "ENABLE_BITCODE": "NO",
     "OTHER_CFLAGS": "-fobjc-arc-exceptions"
+  },
+  "user_target_xcconfig": {
+    "EXCLUDED_ARCHS[sdk=iphonesimulator*]": "arm64"
   }
 }


### PR DESCRIPTION
This settings fixed issue with podspec validation. `pod lib lint`

Apple Silicon provides new simulator architecture which is not supported by EarlGrey.
Those settings are already in `Build settings` but are missing in podspec.
